### PR TITLE
Fix menu bar icon / control center dnd status error

### DIFF
--- a/dnd.sh
+++ b/dnd.sh
@@ -10,6 +10,7 @@ PROCESS_LIST=(
   #cfprefsd
   usernoted
   #NotificationCenter
+  ControlCenter
 )
 
 get_nested_plist(){


### PR DESCRIPTION
Fix menu bar icon / control center dnd status error by restart ControlCenter